### PR TITLE
refined S3 unit test seed; upgraded AWS SDK

### DIFF
--- a/src/Rhetos.LightDMS/Rhetos.LightDMS.csproj
+++ b/src/Rhetos.LightDMS/Rhetos.LightDMS.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Rhetos.CommonConcepts" Version="6.0.0-dev24011711054c6feb" />
     <PackageReference Include="Rhetos.MsSqlEf6" Version="6.0.0-dev24011711054c6feb" />
     <PackageReference Include="Rhetos.Host.AspNet" Version="6.0.0-dev24011711054c6feb" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.305.12" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.500.12" />
   </ItemGroup>
   
   <ItemGroup>

--- a/test/Rhetos.LightDMS.IntegrationTest/DownloadS3StorageTests.cs
+++ b/test/Rhetos.LightDMS.IntegrationTest/DownloadS3StorageTests.cs
@@ -35,12 +35,12 @@ namespace Rhetos.LightDMS.IntegrationTest
 
         private readonly string _fileContent = Guid.NewGuid().ToString();
         private readonly Guid _documentVersionId = Guid.NewGuid();
-        private readonly Guid _fileContentId = Guid.NewGuid();
+        private Guid _fileContentId;
 
         public DownloadS3StorageTests(ITestOutputHelper testOutputHelper)
         {
             _factory = new CustomWebApplicationFactory<Startup>(testOutputHelper);
-            TestDataUtilities.SeedS3StorageFile(_factory, _documentVersionId, _fileContentId, _fileContent);
+            _fileContentId = TestDataUtilities.SeedS3StorageFile(_factory, _documentVersionId, _fileContentId, _fileContent);
         }
 
         public void Dispose()


### PR DESCRIPTION
The AWSSDK.S3 upgrade was necessary because the RequestChecksumCalculation option in AmazonS3Config was not available in version 305. After updating to 500 Ninja tests started passing successfully.